### PR TITLE
Move to more conventional CLI argument spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install git+https://github.com/WillB97/srcomp-pystream.git
 
 Assuming you have [srcomp-http](https://github.com/PeterJCLaw/srcomp-http)
 running on `http://localhost:5112/comp-api/`,
-run `srcomp_pystream --api_url http://localhost:5112/comp-api/`.
+run `srcomp_pystream --api-url http://localhost:5112/comp-api/`.
 
 The output from the stream can be seen via curl, for example: curl http://localhost:8080.
 

--- a/sr/comp/pystream/__main__.py
+++ b/sr/comp/pystream/__main__.py
@@ -49,11 +49,11 @@ def main():
             "wrapping the HTTP API."))
 
     parser.add_argument(
-        '--api_url',
+        '--api-url',
         default=os.environ.get('SRCOMP_API_URL', 'http://localhost:5112/comp-api/'),
         help="The url of the SRComp HTTP API")
     parser.add_argument(
-        '--bind_address', default=os.environ.get('SRCOMP_STREAM_BIND', '127.0.0.1'),
+        '--bind-address', default=os.environ.get('SRCOMP_STREAM_BIND', '127.0.0.1'),
         help="The network address to bind to, defaults to localhost")
     parser.add_argument(
         '--port', type=int, default=os.environ.get('SRCOMP_STREAM_PORT', 8080),


### PR DESCRIPTION
Dashes rather than underscores are much more typical.