### PR TITLE
Better logging & error handling

### DIFF
--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -41,6 +41,9 @@ class CachedState:
                 if response.status == 200:
                     try:
                         data = await response.json()
+                    except UnicodeDecodeError:
+                        LOGGER.error(f"Response from {url!r} could not be decoded: {await response.read()!r}")
+                        data = None
                     except aiohttp.ContentTypeError:
                         LOGGER.error(f"Response from {url!r} is not JSON: {await response.text()!r}")
                         data = None

--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -42,16 +42,16 @@ class CachedState:
                     try:
                         data = await response.json()
                     except aiohttp.ContentTypeError:
-                        LOGGER.error(f"Response from '{url}' is not JSON: {response.text()}")
+                        LOGGER.error(f"Response from {url!r} is not JSON: {response.text()}")
                         data = None
 
                     yield data
                 else:
                     if not (response.status == 404 and silent_404 is True):
-                        LOGGER.error(f"Invalid status code from '{url}': {response.status}")
+                        LOGGER.error(f"Invalid status code from {url!r}: {response.status}")
                     yield None
         except aiohttp.ClientError as e:
-            LOGGER.error(f"Error making request to '{url}': {e}")
+            LOGGER.error(f"Error making request to {url!r}: {e}")
             yield None
 
     async def update_data(self):

--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -42,7 +42,7 @@ class CachedState:
                     try:
                         data = await response.json()
                     except aiohttp.ContentTypeError:
-                        LOGGER.error(f"Response from {url!r} is not JSON: {response.text()}")
+                        LOGGER.error(f"Response from {url!r} is not JSON: {await response.text()!r}")
                         data = None
 
                     yield data

--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import json
 import logging
 from contextlib import asynccontextmanager, suppress
 
@@ -43,6 +44,9 @@ class CachedState:
                         data = await response.json()
                     except UnicodeDecodeError:
                         LOGGER.error(f"Response from {url!r} could not be decoded: {await response.read()!r}")
+                        data = None
+                    except json.JSONDecodeError:
+                        LOGGER.error(f"Response from {url!r} is not valid JSON: {await response.text()!r}")
                         data = None
                     except aiohttp.ContentTypeError:
                         LOGGER.error(f"Response from {url!r} is not JSON: {await response.text()!r}")


### PR DESCRIPTION
This updates `checked_response` to handle various alternative errors which are plausible when dealing with an upstream HTTP service and to log them better.

Most notably this ensures that if there's an error communicating with the upstream HTTP API we don't end up erroring ourselves and then in a tight loop querying it constantly. That repeated load could potentially make issues on the upstream worse (as well as filling up the logs for this service).