### PR TITLE
Pin an older version of setuptools-scm for broader compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2,<8.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2,<8.2"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2,<8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Currently deployments of this package into the compbox do so into the global Python space, which uses the system-installed setuptools which is older than the latest version of setuptools-scm supports. Pin to an older version of setuptools-scm so that such installs continue to work for the time being.