### PR TITLE
Fix seeding of knockout events

### DIFF
--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -24,7 +24,7 @@ class CachedState:
         self.teams = {}
         self.matches = []
         self.last_scored = None
-        self.knockouts = []
+        self.knockouts = None
         self.tiebreaker = None
         self.state_hash = ''
         self.config = {}
@@ -263,7 +263,7 @@ class CachedState:
         })
         if self.last_scored is not None:
             msgs.append({'event': 'last-scored-match', 'data': self.last_scored})
-        if self.knockouts is not []:
+        if self.knockouts is not None:
             msgs.append({'event': 'knockouts', 'data': self.knockouts})
         msgs.append({'event': 'current-delay', 'data': self.current_delay})
         if self.tiebreaker:


### PR DESCRIPTION
This changes from the previous approach, which would always seed knockouts data (though the code wasn't clear that that happened), to matching the behaviour of srcomp-stream -- seeding only if we have a successful response from the API. This is a small change and likely won't impact any clients materially, however does remove the `is not []` comparison which was misleading since `is` does an identity comparison rather than an equality comparison.