### PR TITLE
Add support for knockout structure & brackets

### DIFF
--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -24,7 +24,7 @@ class CachedState:
         self.teams = {}
         self.matches = []
         self.last_scored = None
-        self.knockouts = None
+        self.knockout_rounds = None
         self.tiebreaker = None
         self.state_hash = ''
         self.config = {}
@@ -146,11 +146,12 @@ class CachedState:
         Returns an event message if the value has changed.
         """
         async with self.checked_response('/knockout') as data:
-            new_knockouts = data.get('rounds') if data is not None else None
+            new_rounds = data.get('rounds') if data is not None else None
 
-            if self.knockouts != new_knockouts:
-                self.knockouts = new_knockouts
-                return [{'event': 'knockouts', 'data': new_knockouts}]
+            if self.knockout_rounds != new_rounds:
+                self.knockout_rounds = new_rounds
+                return [{'event': 'knockouts', 'data': new_rounds}]
+
         return []
 
     async def update_tiebreaker(self):
@@ -263,8 +264,8 @@ class CachedState:
         })
         if self.last_scored is not None:
             msgs.append({'event': 'last-scored-match', 'data': self.last_scored})
-        if self.knockouts is not None:
-            msgs.append({'event': 'knockouts', 'data': self.knockouts})
+        if self.knockout_rounds is not None:
+            msgs.append({'event': 'knockouts', 'data': self.knockout_rounds})
         msgs.append({'event': 'current-delay', 'data': self.current_delay})
         if self.tiebreaker:
             msgs.append({'event': 'tiebreaker', 'data': self.tiebreaker})

--- a/sr/comp/pystream/state.py
+++ b/sr/comp/pystream/state.py
@@ -25,6 +25,7 @@ class CachedState:
         self.matches = []
         self.last_scored = None
         self.knockout_rounds = None
+        self.knockout_structure = None
         self.tiebreaker = None
         self.state_hash = ''
         self.config = {}
@@ -152,6 +153,12 @@ class CachedState:
                 self.knockout_rounds = new_rounds
                 return [{'event': 'knockouts', 'data': new_rounds}]
 
+            new_structure = data.get('structure') if data is not None else None
+
+            if self.knockout_structure != new_structure:
+                self.knockout_structure = new_structure
+                return [{'event': 'knockout-structure', 'data': new_structure}]
+
         return []
 
     async def update_tiebreaker(self):
@@ -266,6 +273,8 @@ class CachedState:
             msgs.append({'event': 'last-scored-match', 'data': self.last_scored})
         if self.knockout_rounds is not None:
             msgs.append({'event': 'knockouts', 'data': self.knockout_rounds})
+        if self.knockout_structure is not None:
+            msgs.append({'event': 'knockout-structure', 'data': self.knockout_structure})
         msgs.append({'event': 'current-delay', 'data': self.current_delay})
         if self.tiebreaker:
             msgs.append({'event': 'tiebreaker', 'data': self.tiebreaker})


### PR DESCRIPTION
Payload is equivalent to hitting the `/knockout/structure` endpoint.

This aids support for knockout brackets, used for splitting the display by bracket.

Depends on (includes commits from) #13.

Note: this is untested.

See also:
- https://github.com/PeterJCLaw/srcomp-stream/pull/10
- https://github.com/PeterJCLaw/srcomp-http/pull/23
- https://github.com/PeterJCLaw/srcomp/pull/56
- https://github.com/srobo/srcomp-screens/pull/17
